### PR TITLE
feat: track GitHubPublisher.json metadata file in collection directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: "ID of the Guru collection to sync"
     required: true
   collection_directory_path:
-    description: "Path to the directory where the collection should be synced to"
+    description: "Path to the directory where the collection and metadata file should be synced to"
     required: true
 
 runs:
@@ -34,7 +34,13 @@ runs:
       run: pipenv install
       env:
         PIPENV_PIPFILE: ${{ github.action_path }}/Pipfile
+    # Create the collection directory so we can use it as the working directory
+    # This allows us to keep the metadata file in the same directory as the collection(s)
+    - name: Create the collection directory if it does not exist
+      shell: bash
+      run: mkdir -p  ${{ inputs.collection_directory_path }}
     - name: Sync collection
+      working-directory: ${{ inputs.collection_directory_path }}
       shell: bash
       run: pipenv run python ${{ github.action_path }}/github_publisher.py
       env:
@@ -51,6 +57,6 @@ runs:
         commit_author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
     - uses: stefanzweifel/git-auto-commit-action@8756aa072ef5b4a080af5dc8fef36c5d586e521d # v5.0.0
       with:
-        file_pattern: "*GitHubPublisher.json"
+        file_pattern: "${{ inputs.collection_directory_path }}/GitHubPublisher.json"
         commit_message: "Update GitHubPublisher.json"
         commit_author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"

--- a/github_publisher.py
+++ b/github_publisher.py
@@ -641,15 +641,17 @@ class GitHubPublisher(guru.PublisherFolders):
                 continue
             file_extension = path.splitext(filename)[1]
 
-            collection_path: str = self.get_external_collection_path(card.collection)
+            collection_name = f"{card.collection.name}".rstrip()
+            collection_path = self.get_external_collection_path(card.collection)
             image_relative_path = f"resources/{filename}"
             image_absolute_path = f"{collection_path}/{image_relative_path}"
+            image_download_path = f"{collection_name}/{image_relative_path}"
             guru.download_file(
                 image.attrs.get("src"),
-                image_absolute_path,
+                image_download_path,
                 headers={"Authorization": source._Guru__get_basic_auth_value()},
             )
-            image.attrs["src"] = image_relative_path
+            image.attrs["src"] = f"/{image_absolute_path}"
 
             # Ensure the file extension is tracked by Git LFS
             subprocess.run(
@@ -658,7 +660,7 @@ class GitHubPublisher(guru.PublisherFolders):
 
             # Stage the file for commit
             subprocess.run(
-                ["/usr/bin/git", "add", image_absolute_path], check=True
+                ["/usr/bin/git", "add", image_download_path], check=True
             )  # nosec B603
 
         # Add a title to the content that links to the card in Guru


### PR DESCRIPTION
BREAKING CHANGE: The metadata file (GitHubPublisher.json) will now be kept in the same directory as any collections synced from Guru. Move GitHubPublisher.json to your collection directory defined in `collection_directory_path` of your workflow before using this new version to avoid errors.
