### PR TITLE
feat: do not track `.gitattributes`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ runs:
       run: git pull
     - uses: stefanzweifel/git-auto-commit-action@8756aa072ef5b4a080af5dc8fef36c5d586e521d # v5.0.0
       with:
-        file_pattern: ".gitattributes **/resources/*"
+        file_pattern: "${{ inputs.collection_directory_path }}/**/resources/*"
         commit_message: "Update resources"
         commit_author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
     - uses: stefanzweifel/git-auto-commit-action@8756aa072ef5b4a080af5dc8fef36c5d586e521d # v5.0.0


### PR DESCRIPTION
The `.gitattributes` file will no longer be created or updated by this action. Images will still be tracked using Git LFS. 