### PR TITLE
fix: always update metadata file and resources

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,17 +55,17 @@ runs:
         GURU_COLLECTION_ID: ${{ inputs.guru_collection_id }}
         COLLECTION_DIRECTORY_PATH: ${{ inputs.collection_directory_path }}
     - name: Pull changes from sync so we can update the metadata file
-      if: ${{ !env.DRY_RUN }}
+      if: ${{ !env.DRY_RUN && !cancelled() }}
       shell: bash
       run: git pull
     - uses: stefanzweifel/git-auto-commit-action@8756aa072ef5b4a080af5dc8fef36c5d586e521d # v5.0.0
-      if: ${{ !env.DRY_RUN }}
+      if: ${{ !env.DRY_RUN && !cancelled() }}
       with:
         file_pattern: "${{ inputs.collection_directory_path }}/**/resources/*"
         commit_message: "Update resources"
         commit_author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
     - uses: stefanzweifel/git-auto-commit-action@8756aa072ef5b4a080af5dc8fef36c5d586e521d # v5.0.0
-      if: ${{ !env.DRY_RUN }}
+      if: ${{ !env.DRY_RUN && !cancelled() }}
       with:
         file_pattern: "${{ inputs.collection_directory_path }}/GitHubPublisher.json"
         commit_message: "Update GitHubPublisher.json"


### PR DESCRIPTION
The metadata file will now be updated if changes are detected. This should help keep metadata files accurate even if the script that syncs the content fails somewhere along the way.