### PR TITLE
ci(dependabot): remove group updates configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    groups:
-      production-dependencies:
-        dependency-type: "production"
-      development-dependencies:
-        dependency-type: "development"
     commit-message:
       prefix: "fix"
       prefix-development: "build"
@@ -20,7 +15,3 @@ updates:
       interval: "monthly"
     commit-message:
       prefix: "ci"
-    groups:
-      github-actions:
-        patterns:
-          - "*"


### PR DESCRIPTION
Removes group updates configuration in favor of individual dependency update pull requests from Dependabot.